### PR TITLE
feat: add collapsible nav menu on mobile

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -12,5 +12,6 @@
 </main>
 
 {% include 'partials/footer.njk' %}
+<script src="/static/js/script.js"></script>
 </body>
 </html>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -6,6 +6,13 @@
                 <div>Spencer Harston</div>
             </a>
         </div>
+
+        <a role="button" aria-label="menu" aria-expanded="false" data-target="site-nav" class="nav-burger">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </a>
+
         {% include 'partials/navigation.njk' %}
     </div>
 </header>

--- a/src/_includes/partials/navigation.njk
+++ b/src/_includes/partials/navigation.njk
@@ -1,4 +1,4 @@
-<nav class="site-nav">
+<nav class="site-nav" id="site-nav">
     <ul>
         <li><a href='/posts'>Posts</a></li>
         <li><a href='/about'>About</a></li>

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -166,6 +166,10 @@ header .site-logo-image{
     border-top: 1px solid var(--blueish-2);
 }
 
+#site-nav.is-active ul {
+    justify-content: left;
+}
+
 header .site-nav ul {
     display: flex;
     flex-flow: row wrap;

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -79,7 +79,7 @@ header > div {
     flex-flow: wrap;
     justify-content: space-between;
     align-items: center;
-    column-gap: 2rem;
+    gap: 1rem 2rem;
 
     width: 100%;
     max-width: var(--width-90);
@@ -106,8 +106,65 @@ header .site-logo-image{
     background-color: var(--blueish-0);
 }
 
-/* header .site-nav{
-} */
+/* Main nav burger */
+.nav-burger{
+    cursor: pointer;
+    display: block;
+    position: relative;
+    height: 2rem;
+    width: 2rem;
+}
+
+.nav-burger span {
+    background-color: var(--blueish-4);
+    display: block;
+    height: 1px;
+    width: 16px;
+    position: absolute;
+    left: calc(50% - 8px);
+    transform-origin: center;
+    transition-duration: 86ms;
+    transition-property: background-color,opacity,transform;
+    transition-timing-function: ease-out;
+}
+
+.nav-burger span:nth-child(1){
+    top: calc(50% - 6px);
+}
+.nav-burger span:nth-child(2){
+    top: calc(50% - 1px);
+}
+.nav-burger span:nth-child(3){
+    top: calc(50% + 4px);
+}
+
+.nav-burger.is-active span:nth-child(1){
+    transform: translateY(5px) rotate(45deg);
+}
+
+.nav-burger.is-active span:nth-child(2){
+    opacity: 0;
+}
+
+.nav-burger.is-active span:nth-child(3){
+    transform: translateY(-5px) rotate(-45deg);
+}
+
+/* Main site navigation */
+#site-nav{
+    display: none;
+}
+
+.nav-burger.is-active{
+    margin-left: auto;
+}
+
+#site-nav.is-active{
+    display: block;
+    width: 100%;
+    padding-top: .5rem;
+    border-top: 1px solid var(--blueish-2);
+}
 
 header .site-nav ul {
     display: flex;
@@ -117,7 +174,7 @@ header .site-nav ul {
     align-items: center;
     list-style: none;
     padding: 0;
-    margin: .75rem 0;
+    margin: 0;
 }
 
 header .site-nav li {
@@ -439,5 +496,15 @@ hr.footnotes-sep{
 
     .hr-dashed{
         border-bottom: 1px dashed var(--blueish-1);
+    }
+}
+
+@media (min-width: 1025px) {
+    .nav-burger{
+        display: none;
+    }
+
+    #site-nav{
+        display: block;
     }
 }

--- a/src/static/js/script.js
+++ b/src/static/js/script.js
@@ -1,0 +1,12 @@
+// Main navigation hamburger menu
+const $navBurgers = document.querySelectorAll('.nav-burger');
+if ($navBurgers.length > 0) {
+    $navBurgers.forEach(el => {
+        el.addEventListener('click', () => {
+            const target = el.dataset.target;
+            const $target = document.getElementById(target);
+            el.classList.toggle('is-active');
+            $target.classList.toggle('is-active');
+        });
+    });
+}


### PR DESCRIPTION
Adds a collapsible hamburger menu on mobile (<=1024px). Normal navigation otherwise. Does add a javascript script, but oh well.

Some other minor CSS adjustments as well to account for it.