### PR TITLE
feat: add clean external links plugin

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 const fs = require("node:fs");
 const path = require("node:path");
 const { imageHeaderShortcode, imageMetaShortcode, imageMetaTWShortcode  } = require("./utils/imageGen");
+const safeLinks = require("@sardine/eleventy-plugin-external-links");
 
 
 /**
@@ -132,6 +133,7 @@ module.exports = function(eleventyConfig){
   // add other plugins
   eleventyConfig.addPlugin(readingTime);
   eleventyConfig.addPlugin(pluginRss);
+  eleventyConfig.addPlugin(safeLinks);
 
   return {
     dir: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fontsource/jetbrains-mono": "^4.5.12",
         "@fontsource/noto-sans": "^4.5.11",
         "@fontsource/public-sans": "^4.5.12",
+        "@sardine/eleventy-plugin-external-links": "^1.4.0",
         "async-git": "^1.13.3",
         "eleventy-plugin-reading-time": "^0.0.1",
         "eslint": "^8.32.0",
@@ -346,6 +347,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@sardine/eleventy-plugin-external-links": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sardine/eleventy-plugin-external-links/-/eleventy-plugin-external-links-1.4.0.tgz",
+      "integrity": "sha512-K9WDFQwLMSBo6bjqNmH3kZSdXKTAb0MYHK3Tmm8IChsprF1XHl574U4pxgouTwJNjzlxqPKI/JYbY2okg0tiaQ==",
+      "dev": true,
+      "dependencies": {
+        "linkedom": "^0.13.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@sindresorhus/slugify": {
@@ -686,6 +699,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1115,6 +1134,40 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2371,6 +2424,12 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true
+    },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
@@ -3024,6 +3083,19 @@
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
       "dev": true
+    },
+    "node_modules/linkedom": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.13.7.tgz",
+      "integrity": "sha512-We9cyPHV/exsrC43KXtItjqSTxwrK9pLpOnG6TLzqXrmqwe/wqd3Gi6eAAU4YCqfTgy79R8g75hY2fS7723XUg==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^4.2.1",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^7.2.0",
+        "uhyphen": "^0.1.0"
+      }
     },
     "node_modules/linkify-it": {
       "version": "4.0.1",
@@ -3725,6 +3797,18 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nunjucks": {
@@ -5664,6 +5748,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
+      "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@fontsource/jetbrains-mono": "^4.5.12",
     "@fontsource/noto-sans": "^4.5.11",
     "@fontsource/public-sans": "^4.5.12",
+    "@sardine/eleventy-plugin-external-links": "^1.4.0",
     "async-git": "^1.13.3",
     "eleventy-plugin-reading-time": "^0.0.1",
     "eslint": "^8.32.0",

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -44,7 +44,7 @@ layout: layouts/base
     </div>
     
     <p class="text-s">
-        This post is licensed under <a href="http://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">CC BY 4.0</a> by the author.
+        This post is licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> by the author.
         {%- if image %} Header photo from <a href="{{ image }}">Unsplash</a>.<br>{%- endif %}
         The source for this page is available on {% page_source_link 'GitHub' %}.
     </p>


### PR DESCRIPTION
Adds the [external links plugin](https://www.npmjs.com/package/@sardine/eleventy-plugin-external-links) to add `rel="noreferrer" target="_blank"` to all outgoing links.